### PR TITLE
feat : 특정 게시글 상세정보 불러오기 기능 구현

### DIFF
--- a/src/main/java/com/fab/banggabgo/controller/ArticleController.java
+++ b/src/main/java/com/fab/banggabgo/controller/ArticleController.java
@@ -35,6 +35,14 @@ public class ArticleController {
     return ApiResponse.builder().code(ResponseCode.RESPONSE_CREATED).toEntity();
   }
 
+  @GetMapping("/{id}")
+  public ResponseEntity<?> getArticle(
+      @PathVariable int id
+  ) {
+    var result = articleService.getArticle(id);
+    return ApiResponse.builder().code(ResponseCode.RESPONSE_SUCCESS).data(result).toEntity();
+  }
+
   @PutMapping("/{id}")
   public ResponseEntity<?> putArticle(
       @AuthenticationPrincipal User user,

--- a/src/main/java/com/fab/banggabgo/dto/article/ArticlePageDto.java
+++ b/src/main/java/com/fab/banggabgo/dto/article/ArticlePageDto.java
@@ -47,4 +47,20 @@ public class ArticlePageDto {
             .build())
         .collect(Collectors.toList());
   }
+
+  public static ArticlePageDto toDto(Article article) {
+    return ArticlePageDto.builder()
+        .id(article.getId())
+        .title(article.getTitle())
+        .email(article.getUser().getEmail())
+        .nickname(article.getUser().getNickname())
+        .content(article.getContent())
+        .gender(article.getGender().getValue())
+        .createdDate(article.getCreateDate())
+        .region(article.getRegion().getValue())
+        .period(article.getPeriod().getValue())
+        .price(article.getPrice())
+        .isRecruiting(article.isRecruiting())
+        .build();
+  }
 }

--- a/src/main/java/com/fab/banggabgo/service/ArticleService.java
+++ b/src/main/java/com/fab/banggabgo/service/ArticleService.java
@@ -14,6 +14,11 @@ public interface ArticleService {
   void postArticle(User user, ArticleRegisterDto dto);
 
   /**
+   * 게시글 가져오기
+   */
+  ArticlePageDto getArticle(Integer id);
+
+  /**
    * 게시글 수정
    */
   void putArticle(User user, Integer id, ArticleEditDto dto);

--- a/src/main/java/com/fab/banggabgo/service/impl/ArticleServiceImpl.java
+++ b/src/main/java/com/fab/banggabgo/service/impl/ArticleServiceImpl.java
@@ -85,6 +85,14 @@ public class ArticleServiceImpl implements ArticleService {
   }
 
   @Override
+  public ArticlePageDto getArticle(Integer id) {
+    Article article = articleRepository.findById(id)
+        .orElseThrow(() -> new CustomException(ErrorCode.ARTICLE_NOT_EXISTS));
+
+    return ArticlePageDto.toDto(article);
+  }
+
+  @Override
   public void putArticle(User user, Integer id, ArticleEditDto dto) {
     if (!StringUtils.hasText(dto.getContent()) || !StringUtils.hasText(dto.getTitle())
         || dto.getPrice() < Price.MINPRICE.getValue()

--- a/src/test/java/com/fab/banggabgo/controller/ArticleControllerTest.java
+++ b/src/test/java/com/fab/banggabgo/controller/ArticleControllerTest.java
@@ -168,6 +168,41 @@ class ArticleControllerTest {
   }
 
   @Test
+  @DisplayName("글 가져오기 성공")
+  @WithMockUser
+  void getArticleSuccess() throws Exception {
+    //given
+    //when
+    //then
+    mockMvc.perform(get("/api/articles/1")
+            .with(SecurityMockMvcRequestPostProcessors.csrf()))
+        .andExpect(status().isOk())
+        .andDo(print());
+  }
+
+  @Test
+  @DisplayName("글 가져오기 실패 : 해당 게시글이 존재하지 않음")
+  @WithMockUser
+  void getArticleFail_ARTICLE_NOT_EXISTS() throws Exception {
+    //given
+    doThrow(new CustomException(ErrorCode.ARTICLE_NOT_EXISTS))
+        .when(articleService)
+        .getArticle(anyInt());
+
+    //when
+    MvcResult result = mockMvc.perform(get("/api/articles/1")
+            .with(SecurityMockMvcRequestPostProcessors.csrf()))
+        .andExpect(status().isBadRequest())
+        .andReturn();
+
+    //then
+    String responseBody = result.getResponse().getContentAsString();
+    JsonNode responseJson = objectMapper.readTree(responseBody);
+    String errorCode = responseJson.get("code").asText();
+    assertThat(errorCode).isEqualTo("ARTICLE_NOT_EXISTS");
+  }
+
+  @Test
   @DisplayName("글 수정 성공")
   @WithMockUser
   void putArticleSuccess() throws Exception {

--- a/src/test/java/com/fab/banggabgo/service/impl/ArticleServiceImplTest.java
+++ b/src/test/java/com/fab/banggabgo/service/impl/ArticleServiceImplTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.verify;
 
 import com.fab.banggabgo.common.exception.CustomException;
 import com.fab.banggabgo.dto.article.ArticleEditDto;
+import com.fab.banggabgo.dto.article.ArticlePageDto;
 import com.fab.banggabgo.dto.article.ArticleRegisterDto;
 import com.fab.banggabgo.entity.Article;
 import com.fab.banggabgo.entity.LikeArticle;
@@ -143,6 +144,47 @@ class ArticleServiceImplTest {
 
     //then
     assertEquals(exception.getMessage(), "존재하지 않는 성별 입니다.");
+  }
+
+  @Test
+  @DisplayName("글 가져오기 성공")
+  void getArticleSuccess() {
+    //given
+    Article article = Article.builder().build();
+    article.setId(1);
+    article.setTitle("글" + 1);
+    article.setUser(User.builder()
+        .nickname("유저" + 1)
+        .build());
+    article.setContent("글 내용" + 1);
+    article.setGender(Gender.MALE);
+    article.setCreateDate(LocalDateTime.now());
+    article.setRegion(Seoul.DONGJAK);
+    article.setPeriod(Period.ONETOTHREE);
+    article.setPrice(5000000 + 1);
+    article.setRecruiting(false);
+    article.setDeleted(false);
+
+    given(articleRepository.findById(anyInt()))
+        .willReturn(Optional.ofNullable(article));
+
+    //when
+    ArticlePageDto result = articleService.getArticle(1);
+
+    //then
+    assertEquals("글1", result.getTitle());
+  }
+
+  @Test
+  @DisplayName("글 가져오기 실패 : 해당 게시글이 존재하지 않음")
+  void getArticleFail_ARTICLE_NOT_EXISTS() {
+    //given
+    //when
+    CustomException exception = assertThrows(CustomException.class,
+        () -> articleService.getArticle(1));
+
+    //then
+    assertEquals(exception.getMessage(), "존재하지 않는 게시글 입니다.");
   }
 
   @Test


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**

**TO-BE**
- 게시글 id로 상세정보 가져오는 요청을 보내면 ArticlePageDto 형식으로 응답
- 해당 id의 게시글이 존재하지 않으면 Custom Error 발생

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트 
Swagger로 게시글 id로 요청을 보냈을 때 원하는 정보를 담은 올바른 응답이 나오는지 테스트.
존재하지 않는 id로 요청을 보냈을 때 Custom Error 발생하는지 테스트.
