### PR TITLE
fix : AuthenticationPrincipal로 들어오는 user가 null일 경우 생기는 문제 해결

### DIFF
--- a/src/main/java/com/fab/banggabgo/common/exception/ErrorCode.java
+++ b/src/main/java/com/fab/banggabgo/common/exception/ErrorCode.java
@@ -11,6 +11,11 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode implements Code {
 
   /**
+   * 공통 에러코드
+   */
+  USER_IS_NULL(HttpStatus.BAD_REQUEST, "유저 정보를 불러오는데 실패했습니다."),
+
+  /**
    * 게시글 에러코드
    */
 

--- a/src/main/java/com/fab/banggabgo/config/security/SecurityConfig.java
+++ b/src/main/java/com/fab/banggabgo/config/security/SecurityConfig.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -29,7 +30,7 @@ public class SecurityConfig {
         .authorizeHttpRequests()
         .antMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-resources/**").permitAll()
         .antMatchers("/api/users/**").permitAll()
-        .antMatchers("/api/articles/**").permitAll()
+        .antMatchers(HttpMethod.GET ,"/api/articles/**").permitAll()
         .antMatchers("/login/oauth2/**").permitAll()
         .anyRequest().authenticated()
 

--- a/src/main/java/com/fab/banggabgo/controller/ArticleController.java
+++ b/src/main/java/com/fab/banggabgo/controller/ArticleController.java
@@ -33,7 +33,6 @@ public class ArticleController {
       @AuthenticationPrincipal User user,
       @RequestBody ArticleRegisterForm form
   ) {
-    checkUserNull(user);
     articleService.postArticle(user, ArticleRegisterForm.toDto(form));
     return ApiResponse.builder().code(ResponseCode.RESPONSE_CREATED).toEntity();
   }
@@ -52,7 +51,6 @@ public class ArticleController {
       @PathVariable int id,
       @RequestBody ArticleEditForm form
   ) {
-    checkUserNull(user);
     articleService.putArticle(user, id, ArticleEditForm.toDto(form));
     return ApiResponse.builder().code(ResponseCode.RESPONSE_CREATED).toEntity();
   }
@@ -62,7 +60,6 @@ public class ArticleController {
       @AuthenticationPrincipal User user,
       @PathVariable int id
   ) {
-    checkUserNull(user);
     articleService.deleteArticle(user, id);
     return ApiResponse.builder().code(ResponseCode.RESPONSE_SUCCESS).toEntity();
   }
@@ -103,7 +100,6 @@ public class ArticleController {
       @AuthenticationPrincipal User user,
       @PathVariable int id
   ) {
-    checkUserNull(user);
     var result = articleService.postArticleFavorite(user, id);
     return ApiResponse.builder().code(ResponseCode.RESPONSE_CREATED).data(result).toEntity();
   }
@@ -113,14 +109,7 @@ public class ArticleController {
       @AuthenticationPrincipal User user,
       @PathVariable int id
   ) {
-    checkUserNull(user);
     var result = articleService.getArticleFavorite(user, id);
     return ApiResponse.builder().code(ResponseCode.RESPONSE_SUCCESS).data(result).toEntity();
-  }
-
-  private void checkUserNull(User user) {
-    if (user == null) {
-      throw new CustomException(ErrorCode.USER_IS_NULL);
-    }
   }
 }

--- a/src/main/java/com/fab/banggabgo/controller/ArticleController.java
+++ b/src/main/java/com/fab/banggabgo/controller/ArticleController.java
@@ -2,6 +2,8 @@ package com.fab.banggabgo.controller;
 
 import com.fab.banggabgo.common.ApiResponse;
 import com.fab.banggabgo.common.ResponseCode;
+import com.fab.banggabgo.common.exception.CustomException;
+import com.fab.banggabgo.common.exception.ErrorCode;
 import com.fab.banggabgo.dto.article.ArticleEditForm;
 import com.fab.banggabgo.dto.article.ArticleRegisterForm;
 import com.fab.banggabgo.entity.User;
@@ -31,6 +33,7 @@ public class ArticleController {
       @AuthenticationPrincipal User user,
       @RequestBody ArticleRegisterForm form
   ) {
+    checkUserNull(user);
     articleService.postArticle(user, ArticleRegisterForm.toDto(form));
     return ApiResponse.builder().code(ResponseCode.RESPONSE_CREATED).toEntity();
   }
@@ -49,6 +52,7 @@ public class ArticleController {
       @PathVariable int id,
       @RequestBody ArticleEditForm form
   ) {
+    checkUserNull(user);
     articleService.putArticle(user, id, ArticleEditForm.toDto(form));
     return ApiResponse.builder().code(ResponseCode.RESPONSE_CREATED).toEntity();
   }
@@ -58,6 +62,7 @@ public class ArticleController {
       @AuthenticationPrincipal User user,
       @PathVariable int id
   ) {
+    checkUserNull(user);
     articleService.deleteArticle(user, id);
     return ApiResponse.builder().code(ResponseCode.RESPONSE_SUCCESS).toEntity();
   }
@@ -98,6 +103,7 @@ public class ArticleController {
       @AuthenticationPrincipal User user,
       @PathVariable int id
   ) {
+    checkUserNull(user);
     var result = articleService.postArticleFavorite(user, id);
     return ApiResponse.builder().code(ResponseCode.RESPONSE_CREATED).data(result).toEntity();
   }
@@ -107,7 +113,14 @@ public class ArticleController {
       @AuthenticationPrincipal User user,
       @PathVariable int id
   ) {
+    checkUserNull(user);
     var result = articleService.getArticleFavorite(user, id);
     return ApiResponse.builder().code(ResponseCode.RESPONSE_SUCCESS).data(result).toEntity();
+  }
+
+  private void checkUserNull(User user) {
+    if (user == null) {
+      throw new CustomException(ErrorCode.USER_IS_NULL);
+    }
   }
 }

--- a/src/main/java/com/fab/banggabgo/entity/Article.java
+++ b/src/main/java/com/fab/banggabgo/entity/Article.java
@@ -33,7 +33,7 @@ public class Article extends BaseEntity {
   private Integer id;
 
   @ManyToOne
-  @JoinColumn(name = "user_id")
+  @JoinColumn(name = "user_id", nullable = false)
   @ToString.Exclude
   private User user;
 

--- a/src/main/java/com/fab/banggabgo/service/impl/ArticleServiceImpl.java
+++ b/src/main/java/com/fab/banggabgo/service/impl/ArticleServiceImpl.java
@@ -36,6 +36,8 @@ public class ArticleServiceImpl implements ArticleService {
 
   @Override
   public void postArticle(User user, ArticleRegisterDto dto) {
+    checkUserNull(user);
+
     if (!StringUtils.hasText(dto.getContent()) || !StringUtils.hasText(dto.getTitle())
         || dto.getPrice() < Price.MINPRICE.getValue()
         || dto.getPrice() > Price.MAXPRICE.getValue()) {
@@ -94,6 +96,8 @@ public class ArticleServiceImpl implements ArticleService {
 
   @Override
   public void putArticle(User user, Integer id, ArticleEditDto dto) {
+    checkUserNull(user);
+
     if (!StringUtils.hasText(dto.getContent()) || !StringUtils.hasText(dto.getTitle())
         || dto.getPrice() < Price.MINPRICE.getValue()
         || dto.getPrice() > Price.MAXPRICE.getValue()) {
@@ -144,6 +148,8 @@ public class ArticleServiceImpl implements ArticleService {
 
   @Override
   public void deleteArticle(User user, Integer id) {
+    checkUserNull(user);
+
     Article article = articleRepository.findById(id)
         .orElseThrow(() -> new CustomException(ErrorCode.ARTICLE_NOT_EXISTS));
 
@@ -195,6 +201,8 @@ public class ArticleServiceImpl implements ArticleService {
 
   @Override
   public String postArticleFavorite(User user, Integer id) {
+    checkUserNull(user);
+
     Article article = articleRepository.findById(id)
         .orElseThrow(() -> new CustomException(ErrorCode.ARTICLE_NOT_EXISTS));
 
@@ -218,6 +226,14 @@ public class ArticleServiceImpl implements ArticleService {
 
   @Override
   public boolean getArticleFavorite(User user, Integer id) {
+    checkUserNull(user);
+
     return likeArticleRepository.existsByUserIdAndArticleId(user.getId(), id);
+  }
+
+  private void checkUserNull(User user) {
+    if (user == null) {
+      throw new CustomException(ErrorCode.USER_IS_NULL);
+    }
   }
 }

--- a/src/main/java/com/fab/banggabgo/service/impl/ArticleServiceImpl.java
+++ b/src/main/java/com/fab/banggabgo/service/impl/ArticleServiceImpl.java
@@ -36,7 +36,6 @@ public class ArticleServiceImpl implements ArticleService {
 
   @Override
   public void postArticle(User user, ArticleRegisterDto dto) {
-    checkUserNull(user);
 
     if (!StringUtils.hasText(dto.getContent()) || !StringUtils.hasText(dto.getTitle())
         || dto.getPrice() < Price.MINPRICE.getValue()
@@ -96,7 +95,6 @@ public class ArticleServiceImpl implements ArticleService {
 
   @Override
   public void putArticle(User user, Integer id, ArticleEditDto dto) {
-    checkUserNull(user);
 
     if (!StringUtils.hasText(dto.getContent()) || !StringUtils.hasText(dto.getTitle())
         || dto.getPrice() < Price.MINPRICE.getValue()
@@ -148,7 +146,6 @@ public class ArticleServiceImpl implements ArticleService {
 
   @Override
   public void deleteArticle(User user, Integer id) {
-    checkUserNull(user);
 
     Article article = articleRepository.findById(id)
         .orElseThrow(() -> new CustomException(ErrorCode.ARTICLE_NOT_EXISTS));
@@ -201,7 +198,6 @@ public class ArticleServiceImpl implements ArticleService {
 
   @Override
   public String postArticleFavorite(User user, Integer id) {
-    checkUserNull(user);
 
     Article article = articleRepository.findById(id)
         .orElseThrow(() -> new CustomException(ErrorCode.ARTICLE_NOT_EXISTS));
@@ -226,14 +222,7 @@ public class ArticleServiceImpl implements ArticleService {
 
   @Override
   public boolean getArticleFavorite(User user, Integer id) {
-    checkUserNull(user);
 
     return likeArticleRepository.existsByUserIdAndArticleId(user.getId(), id);
-  }
-
-  private void checkUserNull(User user) {
-    if (user == null) {
-      throw new CustomException(ErrorCode.USER_IS_NULL);
-    }
   }
 }

--- a/src/test/java/com/fab/banggabgo/controller/ArticleControllerTest.java
+++ b/src/test/java/com/fab/banggabgo/controller/ArticleControllerTest.java
@@ -69,6 +69,28 @@ class ArticleControllerTest {
   }
 
   @Test
+  @DisplayName("글 등록 실패 : 존재하지 않는 유저")
+  void postArticleFail_USER_IS_NULL() throws Exception {
+    //given
+    ArticleRegisterForm form = ArticleRegisterForm.builder()
+        .title("글 제목")
+        .region("강남")
+        .period("1개월 ~ 3개월")
+        .price(3000000)
+        .gender("남성")
+        .content("글 내용")
+        .build();
+
+    //when
+    //then
+    mockMvc.perform(post("/api/articles")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(form)))
+        .andExpect(status().isForbidden())
+        .andDo(print());
+  }
+
+  @Test
   @DisplayName("글 등록 실패 : 글 양식 오류")
   @WithMockUser
   void postArticleFail_INVALID_REGISTER() throws Exception {
@@ -228,6 +250,29 @@ class ArticleControllerTest {
   }
 
   @Test
+  @DisplayName("글 수정 실패 : 존재하지 않는 유저")
+  void putArticleFail_USER_IS_NULL() throws Exception {
+    //given
+    ArticleEditForm form = ArticleEditForm.builder()
+        .title("글 제목")
+        .region("강남")
+        .period("1개월 ~ 3개월")
+        .price(3000000)
+        .gender("남성")
+        .content("글 내용")
+        .build();
+
+    //when
+    //then
+    mockMvc.perform(put("/api/articles/1")
+            .header("Authorization", "JWT")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(form)))
+        .andExpect(status().isForbidden())
+        .andDo(print());
+  }
+
+  @Test
   @DisplayName("글 수정 실패 : 글 양식 오류")
   @WithMockUser
   void putArticleFail_INVALID_EDIT() throws Exception {
@@ -374,6 +419,18 @@ class ArticleControllerTest {
   }
 
   @Test
+  @DisplayName("글 삭제 실패 : 존재하지 않는 유저")
+  void deleteArticleFail_USER_IS_NULL() throws Exception {
+    //given
+    //when
+    //then
+    mockMvc.perform(delete("/api/articles/1")
+            .header("Authorization", "JWT"))
+        .andExpect(status().isForbidden())
+        .andDo(print());
+  }
+
+  @Test
   @DisplayName("글 삭제 실패 : 게시글 찾을 수 없음")
   @WithMockUser
   void deleteArticleFail_NOT_FOUND_ARTICLE() throws Exception {
@@ -491,6 +548,18 @@ class ArticleControllerTest {
   }
 
   @Test
+  @DisplayName("글 찜 등록 및 삭제 실패 : 존재하지 않는 유저")
+  void postArticleFavoriteFail_USER_IS_NULL() throws Exception {
+    //given
+    //when
+    //then
+    mockMvc.perform(post("/api/articles/favorites/1")
+            .with(SecurityMockMvcRequestPostProcessors.csrf()))
+        .andExpect(status().isUnauthorized())
+        .andDo(print());
+  }
+
+  @Test
   @DisplayName("글 찜 등록 및 삭제 실패 : 게시글이 존재하지 않음")
   @WithMockUser
   void postArticleFavoriteFail_ARTICLE_NOT_EXISTS() throws Exception {
@@ -522,6 +591,17 @@ class ArticleControllerTest {
     mockMvc.perform(get("/api/articles/favorites/1")
             .with(SecurityMockMvcRequestPostProcessors.csrf()))
         .andExpect(status().isOk())
+        .andDo(print());
+  }
+
+  @Test
+  @DisplayName("글 찜 했는지 여부 가져오기 실패 : 존재하지 않는 유저")
+  void getArticleFavoriteFail_USER_IS_NULL() throws Exception {
+    //given
+    //when
+    //then
+    mockMvc.perform(get("/api/articles/favorites/1"))
+        .andExpect(status().isUnauthorized())
         .andDo(print());
   }
 }

--- a/src/test/java/com/fab/banggabgo/service/impl/ArticleServiceImplTest.java
+++ b/src/test/java/com/fab/banggabgo/service/impl/ArticleServiceImplTest.java
@@ -72,6 +72,18 @@ class ArticleServiceImplTest {
   }
 
   @Test
+  @DisplayName("글 등록 실패 : 존재하지 않는 유저")
+  void postArticleFail_USER_IS_NULL() {
+    //given
+    //when
+    CustomException exception = assertThrows(CustomException.class,
+        () -> articleService.postArticle(null, null));
+
+    //then
+    assertEquals(exception.getMessage(), "유저 정보를 불러오는데 실패했습니다.");
+  }
+
+  @Test
   @DisplayName("글 등록 실패 : 글 양식 오류")
   void postArticleFail_INVALID_REGISTER() {
     //given
@@ -218,6 +230,18 @@ class ArticleServiceImplTest {
   }
 
   @Test
+  @DisplayName("글 수정 실패 : 존재하지 않는 유저")
+  void putArticleFail_USER_IS_NULL() {
+    //given
+    //when
+    CustomException exception = assertThrows(CustomException.class,
+        () -> articleService.putArticle(null, 1, null));
+
+    //then
+    assertEquals(exception.getMessage(), "유저 정보를 불러오는데 실패했습니다.");
+  }
+
+  @Test
   @DisplayName("글 수정 실패 : 글 양식 오류")
   void putArticleFail_INVALID_EDIT() {
     //given
@@ -352,6 +376,18 @@ class ArticleServiceImplTest {
 
     //then
     verify(articleRepository, times(1)).save(any(Article.class));
+  }
+
+  @Test
+  @DisplayName("글 삭제 실패 : 존재하지 않는 유저")
+  void deleteArticleFail_USER_IS_NULL() {
+    //given
+    //when
+    CustomException exception = assertThrows(CustomException.class,
+        () -> articleService.deleteArticle(null, 1));
+
+    //then
+    assertEquals(exception.getMessage(), "유저 정보를 불러오는데 실패했습니다.");
   }
 
   @Test
@@ -557,7 +593,7 @@ class ArticleServiceImplTest {
   }
 
   @Test
-  @DisplayName("글 삭제 성공")
+  @DisplayName("글 전체 개수 가져오기 성공")
   void getArticleTotalCntSuccess() {
     //given
     given(articleRepository.getArticleTotalCnt())
@@ -589,6 +625,18 @@ class ArticleServiceImplTest {
 
     //then
     verify(likeArticleRepository, times(1)).save(any(LikeArticle.class));
+  }
+
+  @Test
+  @DisplayName("글 찜 등록 실패 : 존재하지 않는 유저")
+  void postArticleFavoriteSuccessFail_USER_IS_NULL() {
+    //given
+    //when
+    CustomException exception = assertThrows(CustomException.class,
+        () -> articleService.postArticleFavorite(null, 1));
+
+    //then
+    assertEquals(exception.getMessage(), "유저 정보를 불러오는데 실패했습니다.");
   }
 
   @Test
@@ -631,5 +679,17 @@ class ArticleServiceImplTest {
 
     //then
     assertFalse(result);
+  }
+
+  @Test
+  @DisplayName("글 찜 여부 가져오기 실패 : 존재하지 않는 유저")
+  void getArticleFavoriteSuccessFail_USER_IS_NULL() {
+    //given
+    //when
+    CustomException exception = assertThrows(CustomException.class,
+        () -> articleService.getArticleFavorite(null, 1));
+
+    //then
+    assertEquals(exception.getMessage(), "유저 정보를 불러오는데 실패했습니다.");
   }
 }

--- a/src/test/java/com/fab/banggabgo/service/impl/ArticleServiceImplTest.java
+++ b/src/test/java/com/fab/banggabgo/service/impl/ArticleServiceImplTest.java
@@ -72,18 +72,6 @@ class ArticleServiceImplTest {
   }
 
   @Test
-  @DisplayName("글 등록 실패 : 존재하지 않는 유저")
-  void postArticleFail_USER_IS_NULL() {
-    //given
-    //when
-    CustomException exception = assertThrows(CustomException.class,
-        () -> articleService.postArticle(null, null));
-
-    //then
-    assertEquals(exception.getMessage(), "유저 정보를 불러오는데 실패했습니다.");
-  }
-
-  @Test
   @DisplayName("글 등록 실패 : 글 양식 오류")
   void postArticleFail_INVALID_REGISTER() {
     //given
@@ -230,18 +218,6 @@ class ArticleServiceImplTest {
   }
 
   @Test
-  @DisplayName("글 수정 실패 : 존재하지 않는 유저")
-  void putArticleFail_USER_IS_NULL() {
-    //given
-    //when
-    CustomException exception = assertThrows(CustomException.class,
-        () -> articleService.putArticle(null, 1, null));
-
-    //then
-    assertEquals(exception.getMessage(), "유저 정보를 불러오는데 실패했습니다.");
-  }
-
-  @Test
   @DisplayName("글 수정 실패 : 글 양식 오류")
   void putArticleFail_INVALID_EDIT() {
     //given
@@ -376,18 +352,6 @@ class ArticleServiceImplTest {
 
     //then
     verify(articleRepository, times(1)).save(any(Article.class));
-  }
-
-  @Test
-  @DisplayName("글 삭제 실패 : 존재하지 않는 유저")
-  void deleteArticleFail_USER_IS_NULL() {
-    //given
-    //when
-    CustomException exception = assertThrows(CustomException.class,
-        () -> articleService.deleteArticle(null, 1));
-
-    //then
-    assertEquals(exception.getMessage(), "유저 정보를 불러오는데 실패했습니다.");
   }
 
   @Test
@@ -628,18 +592,6 @@ class ArticleServiceImplTest {
   }
 
   @Test
-  @DisplayName("글 찜 등록 실패 : 존재하지 않는 유저")
-  void postArticleFavoriteSuccessFail_USER_IS_NULL() {
-    //given
-    //when
-    CustomException exception = assertThrows(CustomException.class,
-        () -> articleService.postArticleFavorite(null, 1));
-
-    //then
-    assertEquals(exception.getMessage(), "유저 정보를 불러오는데 실패했습니다.");
-  }
-
-  @Test
   @DisplayName("글 찜 삭제 성공")
   void postArticleFavoriteSuccess_DELETE() {
     //given
@@ -679,17 +631,5 @@ class ArticleServiceImplTest {
 
     //then
     assertFalse(result);
-  }
-
-  @Test
-  @DisplayName("글 찜 여부 가져오기 실패 : 존재하지 않는 유저")
-  void getArticleFavoriteSuccessFail_USER_IS_NULL() {
-    //given
-    //when
-    CustomException exception = assertThrows(CustomException.class,
-        () -> articleService.getArticleFavorite(null, 1));
-
-    //then
-    assertEquals(exception.getMessage(), "유저 정보를 불러오는데 실패했습니다.");
   }
 }


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- User가 null인 경우에도 글작성, 수정, 삭제 / 찜등록, 찜 여부 가져오기 api가 실행이 됨
- DB에 user가 Null인 상태로 저장

**TO-BE**
- SecurityConfig에서 "/api/articles/**"로 들어오는 요청 중 GET 메소드만 permitAll
- ArticleService에서 user가 null인지 check하는 로직 추가
- Article 엔티티에 user "nullable = false" 추가
- User가 Null인 경우 CustomException 발생하는지 테스트 코드 작성