### PR TITLE
feat : 프로필 추천 기능 구현

### DIFF
--- a/src/main/java/com/fab/banggabgo/config/security/SecurityConfig.java
+++ b/src/main/java/com/fab/banggabgo/config/security/SecurityConfig.java
@@ -29,6 +29,7 @@ public class SecurityConfig {
         .and()
         .authorizeHttpRequests()
         .antMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-resources/**").permitAll()
+        .antMatchers("/api/users/recommend").authenticated()
         .antMatchers("/api/users/**").permitAll()
         .antMatchers(HttpMethod.GET ,"/api/articles/**").permitAll()
         .antMatchers("/login/oauth2/**").permitAll()

--- a/src/main/java/com/fab/banggabgo/controller/RecommendController.java
+++ b/src/main/java/com/fab/banggabgo/controller/RecommendController.java
@@ -1,0 +1,30 @@
+package com.fab.banggabgo.controller;
+
+import com.fab.banggabgo.common.ApiResponse;
+import com.fab.banggabgo.common.ResponseCode;
+import com.fab.banggabgo.entity.User;
+import com.fab.banggabgo.service.RecommendService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/users")
+public class RecommendController {
+
+  private final RecommendService recommendService;
+
+  @GetMapping("/recommend")
+  public ResponseEntity<?> getRecommendUsers(
+      @AuthenticationPrincipal User user,
+      @RequestParam(defaultValue = "9") Integer size
+  ) {
+    var result = recommendService.getRecommendUsers(user, size);
+    return ApiResponse.builder().code(ResponseCode.RESPONSE_SUCCESS).data(result).toEntity();
+  }
+}

--- a/src/main/java/com/fab/banggabgo/dto/recommend/RecommendDto.java
+++ b/src/main/java/com/fab/banggabgo/dto/recommend/RecommendDto.java
@@ -1,0 +1,32 @@
+package com.fab.banggabgo.dto.recommend;
+
+import com.fab.banggabgo.entity.User;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RecommendDto {
+
+  private Integer id;
+  private String nickname;
+  private String mbti;
+
+  public static List<RecommendDto> toDtoList(List<User> userList) {
+    return userList.stream()
+        .map(user -> RecommendDto.builder()
+            .id(user.getId())
+            .nickname(user.getNickname())
+            .mbti(user.getMbti().toString())
+            .build())
+        .collect(Collectors.toList());
+  }
+}

--- a/src/main/java/com/fab/banggabgo/dto/recommend/RecommendResponseDto.java
+++ b/src/main/java/com/fab/banggabgo/dto/recommend/RecommendResponseDto.java
@@ -1,0 +1,19 @@
+package com.fab.banggabgo.dto.recommend;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RecommendResponseDto {
+
+  private String mbti;
+  private List<RecommendDto> recommendDtoList;
+}

--- a/src/main/java/com/fab/banggabgo/repository/UserRepositoryCustom.java
+++ b/src/main/java/com/fab/banggabgo/repository/UserRepositoryCustom.java
@@ -1,8 +1,11 @@
 package com.fab.banggabgo.repository;
 
 import com.fab.banggabgo.entity.User;
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepositoryCustom {
   Optional<User> findByEmail(String email);
+
+  List<User> getRecommend(User user, Integer size);
 }

--- a/src/main/java/com/fab/banggabgo/repository/impl/UserRepositoryImpl.java
+++ b/src/main/java/com/fab/banggabgo/repository/impl/UserRepositoryImpl.java
@@ -3,7 +3,9 @@ package com.fab.banggabgo.repository.impl;
 import com.fab.banggabgo.entity.QUser;
 import com.fab.banggabgo.entity.User;
 import com.fab.banggabgo.repository.UserRepositoryCustom;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 
@@ -18,6 +20,23 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
             .leftJoin(qUser.tag).fetchJoin()
         .where(qUser.email.eq(email));
     return Optional.ofNullable(query.fetchOne());
+  }
+
+  @Override
+  public List<User> getRecommend(User user, Integer size) {
+
+    var userQuery = queryFactory.selectFrom(qUser)
+        .where(qUser.gender.eq(user.getGender())
+            .and(qUser.isSmoker.eq(user.getIsSmoker())
+                .and(qUser.region.eq(user.getRegion())
+                    .and(qUser.activityTime.eq(user.getActivityTime())
+                        .and(qUser.minAge.eq(user.getMinAge())
+                            .and(qUser.maxAge.eq(user.getMaxAge())
+                                .and(qUser.id.ne(user.getId()))))))))
+        .orderBy(Expressions.numberTemplate(Double.class, "function('rand')").asc())
+        .limit(size);
+
+    return userQuery.fetch();
   }
 
 }

--- a/src/main/java/com/fab/banggabgo/repository/impl/UserRepositoryImpl.java
+++ b/src/main/java/com/fab/banggabgo/repository/impl/UserRepositoryImpl.java
@@ -11,13 +11,15 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public class UserRepositoryImpl implements UserRepositoryCustom {
+
   private final JPAQueryFactory queryFactory;
   QUser qUser = QUser.user;
-  public Optional<User> findByEmail(String email){
-    var query=queryFactory.selectFrom(qUser)
-            .leftJoin(qUser.roles).fetchJoin()
-            .leftJoin(qUser.tag).fetchJoin()
-            .leftJoin(qUser.tag).fetchJoin()
+
+  public Optional<User> findByEmail(String email) {
+    var query = queryFactory.selectFrom(qUser)
+        .leftJoin(qUser.roles).fetchJoin()
+        .leftJoin(qUser.tag).fetchJoin()
+        .leftJoin(qUser.tag).fetchJoin()
         .where(qUser.email.eq(email));
     return Optional.ofNullable(query.fetchOne());
   }
@@ -27,12 +29,12 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
 
     var userQuery = queryFactory.selectFrom(qUser)
         .where(qUser.gender.eq(user.getGender())
-            .and(qUser.isSmoker.eq(user.getIsSmoker())
-                .and(qUser.region.eq(user.getRegion())
-                    .and(qUser.activityTime.eq(user.getActivityTime())
-                        .and(qUser.minAge.eq(user.getMinAge())
-                            .and(qUser.maxAge.eq(user.getMaxAge())
-                                .and(qUser.id.ne(user.getId()))))))))
+            .and(qUser.isSmoker.eq(user.getIsSmoker()))
+            .and(qUser.region.eq(user.getRegion()))
+            .and(qUser.activityTime.eq(user.getActivityTime()))
+            .and(qUser.minAge.eq(user.getMinAge()))
+            .and(qUser.maxAge.eq(user.getMaxAge()))
+            .and(qUser.id.ne(user.getId())))
         .orderBy(Expressions.numberTemplate(Double.class, "function('rand')").asc())
         .limit(size);
 

--- a/src/main/java/com/fab/banggabgo/service/RecommendService.java
+++ b/src/main/java/com/fab/banggabgo/service/RecommendService.java
@@ -1,0 +1,12 @@
+package com.fab.banggabgo.service;
+
+import com.fab.banggabgo.dto.recommend.RecommendResponseDto;
+import com.fab.banggabgo.entity.User;
+
+public interface RecommendService {
+
+  /**
+   * 프로필 추천 불러오기
+   */
+  RecommendResponseDto getRecommendUsers(User user, Integer size);
+}

--- a/src/main/java/com/fab/banggabgo/service/impl/RecommendServiceImpl.java
+++ b/src/main/java/com/fab/banggabgo/service/impl/RecommendServiceImpl.java
@@ -1,0 +1,30 @@
+package com.fab.banggabgo.service.impl;
+
+import com.fab.banggabgo.common.exception.CustomException;
+import com.fab.banggabgo.common.exception.ErrorCode;
+import com.fab.banggabgo.dto.recommend.RecommendDto;
+import com.fab.banggabgo.dto.recommend.RecommendResponseDto;
+import com.fab.banggabgo.entity.User;
+import com.fab.banggabgo.repository.UserRepository;
+import com.fab.banggabgo.service.RecommendService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RecommendServiceImpl implements RecommendService {
+
+  private final UserRepository userRepository;
+
+  @Override
+  public RecommendResponseDto getRecommendUsers(User user, Integer size) {
+
+    List<User> userList = userRepository.getRecommend(user, size);
+
+    return RecommendResponseDto.builder()
+        .mbti(user.getMbti().toString())
+        .recommendDtoList(RecommendDto.toDtoList(userList))
+        .build();
+  }
+}

--- a/src/test/java/com/fab/banggabgo/controller/RecommendControllerTest.java
+++ b/src/test/java/com/fab/banggabgo/controller/RecommendControllerTest.java
@@ -1,0 +1,53 @@
+package com.fab.banggabgo.controller;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fab.banggabgo.service.RecommendService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(RecommendController.class)
+@ExtendWith(MockitoExtension.class)
+class RecommendControllerTest {
+
+  @MockBean
+  private RecommendService recommendService;
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Test
+  @DisplayName("프로필 추천 불러오기 성공")
+  @WithMockUser
+  void getRecommendUsersSuccess() throws Exception {
+    //given
+    //when
+    //then
+    mockMvc.perform(get("/api/users/recommend?size=9")
+            .with(SecurityMockMvcRequestPostProcessors.csrf()))
+        .andExpect(status().isOk())
+        .andDo(print());
+  }
+
+  @Test
+  @DisplayName("프로필 추천 불러오기 실패 : 존재하지 않는 유저")
+  void getRecommendUsersFail_USER_IS_NULL() throws Exception {
+    //given
+    //when
+    //then
+    mockMvc.perform(get("/api/users/recommend?size=9"))
+        .andExpect(status().isUnauthorized())
+        .andDo(print());
+  }
+}

--- a/src/test/java/com/fab/banggabgo/service/impl/RecommendServiceImplTest.java
+++ b/src/test/java/com/fab/banggabgo/service/impl/RecommendServiceImplTest.java
@@ -1,0 +1,60 @@
+package com.fab.banggabgo.service.impl;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.BDDMockito.given;
+
+import com.fab.banggabgo.dto.recommend.RecommendResponseDto;
+import com.fab.banggabgo.entity.User;
+import com.fab.banggabgo.repository.UserRepository;
+import com.fab.banggabgo.type.Mbti;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RecommendServiceImplTest {
+
+  @Mock
+  private UserRepository userRepository;
+
+  @InjectMocks
+  private RecommendServiceImpl recommendService;
+
+  @Test
+  @DisplayName("프로필 추천 불러오기 성공")
+  void getRecommendUsersSuccess() {
+    //given
+    List<User> userList = new ArrayList<>();
+
+    for (int i = 0; i < 9; i++) {
+      User user = User.builder()
+          .id(i + 1)
+          .nickname("유저" + i)
+          .mbti(Mbti.ENTJ)
+          .build();
+
+      userList.add(user);
+    }
+
+    given(userRepository.getRecommend(any(), anyInt()))
+        .willReturn(userList);
+
+    User user1 = User.builder()
+        .mbti(Mbti.ENFJ)
+        .build();
+    //when
+    RecommendResponseDto result = recommendService.getRecommendUsers(user1, 9);
+
+    //then
+    assertEquals(9, result.getRecommendDtoList().size());
+    assertEquals("ENFJ", result.getMbti());
+  }
+}


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**

**TO-BE**
- user와 size를 받으면 해당 user와 성별, 흡연유무, 지역, 활동시간, 원하는 연령대가 같은 user 목록을 랜덤으로 size만큼 가져옴
- 응답으로 로그인한 유저의 mbti와 추천 유저들의 id, 닉네임, mbti 정보를 보냄
- 로그인 안한 유저의 요청은 403에러 발생
- Swagger로 API 테스트, Controlelr, Service 테스트 코드 작성

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트
DB에 프로필 정보를 담은 유저 53명을 저장하고 프로필 추천 API를 정상적으로 요청했을 때 추천 대상 유저들이 무작위로 결과가 나오는지 테스트.
로그인 하지 않은 유저가 요청을 보냈을 때 403 에러가 발생하는지 테스트

