### PR TITLE
fix : 게시글 페이지 불러오기 수정

### DIFF
--- a/src/main/java/com/fab/banggabgo/controller/ArticleController.java
+++ b/src/main/java/com/fab/banggabgo/controller/ArticleController.java
@@ -80,12 +80,6 @@ public class ArticleController {
     return ApiResponse.builder().code(ResponseCode.RESPONSE_SUCCESS).data(result).toEntity();
   }
 
-  @GetMapping("/total")
-  public ResponseEntity<?> getArticleTotalCnt() {
-    var result = articleService.getArticleTotalCnt();
-    return ApiResponse.builder().code(ResponseCode.RESPONSE_SUCCESS).data(result).toEntity();
-  }
-
   @GetMapping("/filter")
   public ResponseEntity<?> getArticleByFilter(
       @RequestParam("page") Integer page,

--- a/src/main/java/com/fab/banggabgo/dto/article/ArticlePageResultDto.java
+++ b/src/main/java/com/fab/banggabgo/dto/article/ArticlePageResultDto.java
@@ -1,0 +1,28 @@
+package com.fab.banggabgo.dto.article;
+
+import com.fab.banggabgo.entity.Article;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.domain.Page;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ArticlePageResultDto {
+
+  private long totalCnt;
+  private List<ArticlePageDto> articleList;
+
+  public static ArticlePageResultDto toDto(Page<Article> articlePage) {
+    return ArticlePageResultDto.builder()
+        .totalCnt(articlePage.getTotalElements())
+        .articleList(ArticlePageDto.toDtoList(articlePage))
+        .build();
+  }
+}

--- a/src/main/java/com/fab/banggabgo/repository/impl/ArticleRepositoryImpl.java
+++ b/src/main/java/com/fab/banggabgo/repository/impl/ArticleRepositoryImpl.java
@@ -39,13 +39,20 @@ public class ArticleRepositoryImpl implements ArticleRepositoryCustom {
         .limit(pageable.getPageSize())
         .distinct();
 
+    var articleCountQuery = queryFactory.select(qArticle.count())
+        .from(qArticle)
+        .join(qArticle.user, qUser)
+        .where(qArticle.isDeleted.eq(false))
+        .distinct();
+
     if (isRecruiting) {
       articleQuery = articleQuery.where(qArticle.isRecruiting.eq(true));
+      articleCountQuery = articleCountQuery.where(qArticle.isRecruiting.eq(true));
     }
 
     List<Article> articleList = articleQuery.fetch();
 
-    return new PageImpl<>(articleList);
+    return new PageImpl<>(articleList, pageable, articleCountQuery.fetchOne());
   }
 
   public Page<Article> getArticleByFilter(Pageable pageable, boolean isRecruiting, String region,
@@ -62,29 +69,40 @@ public class ArticleRepositoryImpl implements ArticleRepositoryCustom {
         .limit(pageable.getPageSize())
         .distinct();
 
+    var articleCountQuery = queryFactory.select(qArticle.count())
+        .from(qArticle)
+        .join(qArticle.user, qUser)
+        .where(qArticle.isDeleted.eq(false))
+        .distinct();
+
     if (isRecruiting) {
       articleQuery = articleQuery.where(qArticle.isRecruiting.eq(true));
+      articleCountQuery = articleCountQuery.where(qArticle.isRecruiting.eq(true));
     }
 
     if (!"상관 없음".equals(region)) {
       articleQuery = articleQuery.where(qArticle.region.eq(Seoul.fromValue(region)));
+      articleCountQuery = articleCountQuery.where(qArticle.region.eq(Seoul.fromValue(region)));
     }
 
     if (!"상관 없음".equals(period)) {
       articleQuery = articleQuery.where(qArticle.period.eq(Period.fromValue(period)));
+      articleCountQuery = articleCountQuery.where(qArticle.period.eq(Period.fromValue(period)));
     }
 
     if (!"상관 없음".equals(price)) {
       articleQuery = articleQuery.where(qArticle.price.loe(Integer.parseInt(price)));
+      articleCountQuery = articleCountQuery.where(qArticle.price.loe(Integer.parseInt(price)));
     }
 
     if (!"상관 없음".equals(gender)) {
       articleQuery = articleQuery.where(qArticle.gender.eq(Gender.fromValue(gender)));
+      articleCountQuery = articleCountQuery.where(qArticle.gender.eq(Gender.fromValue(gender)));
     }
 
     List<Article> articleList = articleQuery.fetch();
 
-    return new PageImpl<>(articleList);
+    return new PageImpl<>(articleList, pageable, articleCountQuery.fetchOne());
   }
 
   @Override

--- a/src/main/java/com/fab/banggabgo/service/ArticleService.java
+++ b/src/main/java/com/fab/banggabgo/service/ArticleService.java
@@ -4,6 +4,7 @@ import com.fab.banggabgo.dto.apply.ApplyUserResultDto;
 import com.fab.banggabgo.dto.article.ArticleEditDto;
 import com.fab.banggabgo.dto.article.ArticleInfoDto;
 import com.fab.banggabgo.dto.article.ArticlePageDto;
+import com.fab.banggabgo.dto.article.ArticlePageResultDto;
 import com.fab.banggabgo.dto.article.ArticleRegisterDto;
 import com.fab.banggabgo.entity.User;
 import java.util.List;
@@ -38,18 +39,13 @@ public interface ArticleService {
   /**
    * 게시글 페이징 불러오기
    */
-  List<ArticlePageDto> getArticleByPageable(Integer page, Integer size, boolean isRecruiting);
+  ArticlePageResultDto getArticleByPageable(Integer page, Integer size, boolean isRecruiting);
 
   /**
    * 게시글 검색하기
    */
-  List<ArticlePageDto> getArticleByFilter(Integer page, Integer size, boolean isRecruiting,
+  ArticlePageResultDto getArticleByFilter(Integer page, Integer size, boolean isRecruiting,
       String region, String period, String price, String gender);
-
-  /**
-   * 게시글 전체 개수
-   */
-  Integer getArticleTotalCnt();
 
   /**
    * 게시글 찜 등록/삭제

--- a/src/main/java/com/fab/banggabgo/service/impl/ArticleServiceImpl.java
+++ b/src/main/java/com/fab/banggabgo/service/impl/ArticleServiceImpl.java
@@ -6,6 +6,7 @@ import com.fab.banggabgo.dto.apply.ApplyUserResultDto;
 import com.fab.banggabgo.dto.article.ArticleEditDto;
 import com.fab.banggabgo.dto.article.ArticleInfoDto;
 import com.fab.banggabgo.dto.article.ArticlePageDto;
+import com.fab.banggabgo.dto.article.ArticlePageResultDto;
 import com.fab.banggabgo.dto.article.ArticleRegisterDto;
 import com.fab.banggabgo.entity.Apply;
 import com.fab.banggabgo.entity.Article;
@@ -180,7 +181,7 @@ public class ArticleServiceImpl implements ArticleService {
   }
 
   @Override
-  public List<ArticlePageDto> getArticleByPageable(Integer page, Integer size,
+  public ArticlePageResultDto getArticleByPageable(Integer page, Integer size,
       boolean isRecruiting) {
 
     page = page < 1 ? 1 : page;
@@ -189,11 +190,11 @@ public class ArticleServiceImpl implements ArticleService {
 
     Page<Article> articleList = articleRepository.getArticle(pageable, isRecruiting);
 
-    return ArticlePageDto.toDtoList(articleList);
+    return ArticlePageResultDto.toDto(articleList);
   }
 
   @Override
-  public List<ArticlePageDto> getArticleByFilter(Integer page, Integer size, boolean isRecruiting,
+  public ArticlePageResultDto getArticleByFilter(Integer page, Integer size, boolean isRecruiting,
       String region, String period, String price, String gender) {
 
     page = page < 1 ? 1 : page;
@@ -203,13 +204,7 @@ public class ArticleServiceImpl implements ArticleService {
     Page<Article> articleList = articleRepository.getArticleByFilter(pageable, isRecruiting, region,
         period, price, gender);
 
-    return ArticlePageDto.toDtoList(articleList);
-  }
-
-  @Override
-  public Integer getArticleTotalCnt() {
-
-    return articleRepository.getArticleTotalCnt();
+    return ArticlePageResultDto.toDto(articleList);
   }
 
   @Override

--- a/src/test/java/com/fab/banggabgo/controller/ArticleControllerTest.java
+++ b/src/test/java/com/fab/banggabgo/controller/ArticleControllerTest.java
@@ -559,19 +559,6 @@ class ArticleControllerTest {
   }
 
   @Test
-  @DisplayName("게시글 총 개수 가져오기")
-  @WithMockUser
-  void getArticleTotalCntSuccess() throws Exception {
-    //given
-    //when
-    //then
-    mockMvc.perform(get("/api/articles/total")
-            .with(SecurityMockMvcRequestPostProcessors.csrf()))
-        .andExpect(status().isOk())
-        .andDo(print());
-  }
-
-  @Test
   @DisplayName("글 찜 등록 및 삭제 성공")
   @WithMockUser
   void postArticleFavoriteSuccess() throws Exception {

--- a/src/test/java/com/fab/banggabgo/service/impl/ArticleServiceImplTest.java
+++ b/src/test/java/com/fab/banggabgo/service/impl/ArticleServiceImplTest.java
@@ -507,7 +507,7 @@ class ArticleServiceImplTest {
     var result = articleService.getArticleByPageable(1, 5, true);
 
     //then
-    assertEquals(5, result.size());
+    assertEquals(5, result.getArticleList().size());
   }
 
   @Test
@@ -541,7 +541,7 @@ class ArticleServiceImplTest {
     var result = articleService.getArticleByPageable(1, 5, false);
 
     //then
-    assertEquals(5, result.size());
+    assertEquals(5, result.getArticleList().size());
   }
 
   @Test
@@ -576,7 +576,7 @@ class ArticleServiceImplTest {
     var result = articleService.getArticleByFilter(1, 5, true, "서초구", "1개월 ~ 3개월", "1000000", "남성");
 
     //then
-    assertEquals(5, result.size());
+    assertEquals(5, result.getArticleList().size());
   }
 
   @Test
@@ -612,21 +612,7 @@ class ArticleServiceImplTest {
         "남성");
 
     //then
-    assertEquals(5, result.size());
-  }
-
-  @Test
-  @DisplayName("글 전체 개수 가져오기 성공")
-  void getArticleTotalCntSuccess() {
-    //given
-    given(articleRepository.getArticleTotalCnt())
-        .willReturn(5);
-
-    //when
-    Integer result = articleService.getArticleTotalCnt();
-
-    //then
-    assertEquals(5, result);
+    assertEquals(5, result.getArticleList().size());
   }
 
   @Test


### PR DESCRIPTION
### 변경사항
**AS-IS**
- 게시글 페이지 목록 가져올 때 게시글 목록만 응답
- 게시글 총 개수 구하는 API 따로 존재

**TO-BE**
- 게시글 페이지 목록 가져오는 API에 해당하는 글 총 개수도 포함
- 게시글 총 개수 구하는 API 삭제

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트 
게시글 페이지 가져오는 API에 올바른 totalCnt 값이 포함되는지 테스트.
검색 결과 게시글 페이지 가져오는 API에 검색 조건들을 변경하며 totalCnt 값이 올바르게 변경되는지 테스트.
수정사항 테스트 코드에 적용