### PR TITLE
fix : Article 게시글 조회, 수정, 삭제 수정

### DIFF
--- a/src/main/java/com/fab/banggabgo/repository/ApplyRepository.java
+++ b/src/main/java/com/fab/banggabgo/repository/ApplyRepository.java
@@ -1,6 +1,8 @@
 package com.fab.banggabgo.repository;
 
 import com.fab.banggabgo.entity.Apply;
+import com.fab.banggabgo.type.ApproveStatus;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -11,4 +13,6 @@ public interface ApplyRepository extends JpaRepository<Apply, Integer>, ApplyRep
   boolean existsByApplicantUserIdAndArticleId(Integer applicantUserId, Integer articleId);
 
   Optional<Apply> findByApplicantUserIdAndArticleId(Integer id, Integer articleId);
+
+  List<Apply> findByArticleIdAndApproveStatus(Integer articleId, ApproveStatus approveStatus);
 }

--- a/src/main/java/com/fab/banggabgo/repository/impl/ArticleRepositoryImpl.java
+++ b/src/main/java/com/fab/banggabgo/repository/impl/ArticleRepositoryImpl.java
@@ -40,7 +40,7 @@ public class ArticleRepositoryImpl implements ArticleRepositoryCustom {
         .join(qArticle.user, qUser)
         .fetchJoin()
         .orderBy(qArticle.createDate.desc())
-        .where(eqDelete(false),eqRecruiting(true))
+        .where(eqDelete(false))
         .offset(pageable.getOffset())
         .limit(pageable.getPageSize())
         .distinct();
@@ -71,7 +71,6 @@ public class ArticleRepositoryImpl implements ArticleRepositoryCustom {
         .fetchJoin()
         .orderBy(qArticle.createDate.desc())
         .where(eqDelete(false)
-            ,eqRecruiting(true)
             ,eqGender(gender)
             ,eqPeriod(period)
             ,eqRegion(region)
@@ -84,8 +83,17 @@ public class ArticleRepositoryImpl implements ArticleRepositoryCustom {
     var articleCountQuery = queryFactory.select(qArticle.count())
         .from(qArticle)
         .join(qArticle.user, qUser)
-        .where(qArticle.isDeleted.eq(false))
+        .where(eqDelete(false)
+            ,eqGender(gender)
+            ,eqPeriod(period)
+            ,eqRegion(region)
+            ,loePrice(price))
         .distinct();
+
+    if (isRecruiting) {
+      articleQuery = articleQuery.where(qArticle.isRecruiting.eq(true));
+      articleCountQuery = articleCountQuery.where(qArticle.isRecruiting.eq(true));
+    }
 
     List<Article> articleList = articleQuery.fetch();
 

--- a/src/main/java/com/fab/banggabgo/service/impl/ArticleServiceImpl.java
+++ b/src/main/java/com/fab/banggabgo/service/impl/ArticleServiceImpl.java
@@ -148,6 +148,10 @@ public class ArticleServiceImpl implements ArticleService {
       throw new CustomException(ErrorCode.ARTICLE_DELETED);
     }
 
+    if (!article.isRecruiting()) {
+      throw new CustomException(ErrorCode.ALREADY_END_RECRUITING);
+    }
+
     if (!Objects.equals(article.getUser().getId(), user.getId())) {
       throw new CustomException(ErrorCode.USER_NOT_MATCHED);
     }
@@ -177,6 +181,14 @@ public class ArticleServiceImpl implements ArticleService {
     }
 
     article.setDeleted(true);
+
+    List<Apply> applyList = applyRepository.findByArticleIdAndApproveStatus(id, ApproveStatus.WAIT);
+
+    for (Apply apply : applyList) {
+      apply.setApproveStatus(ApproveStatus.REFUSE);
+    }
+
+    applyRepository.saveAll(applyList);
 
     articleRepository.save(article);
   }

--- a/src/test/java/com/fab/banggabgo/service/impl/ArticleServiceImplTest.java
+++ b/src/test/java/com/fab/banggabgo/service/impl/ArticleServiceImplTest.java
@@ -267,6 +267,7 @@ class ArticleServiceImplTest {
         .willReturn(Optional.ofNullable(Article.builder()
             .user(user)
             .isDeleted(false)
+            .isRecruiting(true)
             .build()));
 
     //when
@@ -382,6 +383,7 @@ class ArticleServiceImplTest {
         .willReturn(Optional.ofNullable(Article.builder()
             .user(user2)
             .isDeleted(false)
+            .isRecruiting(true)
             .build()));
 
     //when
@@ -745,6 +747,7 @@ class ArticleServiceImplTest {
         .isApplicantDelete(false)
         .isArticleUserDelete(false)
         .build();
+
     @Test
     @DisplayName("apply - 처음 신청 성공")
     void applySuccess() {
@@ -752,7 +755,6 @@ class ArticleServiceImplTest {
           anyInt())).willReturn(Optional.empty());
       given(articleRepository.findById(anyInt())).willReturn(Optional.of(article));
       given(applyRepository.save(any())).willReturn(apply);
-
 
       var result = articleService.applyUser(loginUser, article.getId());
 


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 게시글 목록 불러올 때 항상 isRecruiting = true인 게시글 만 불러옴
- 게시글 검색시 countQuery에 검색 조건 없음
- 게시글 수정시 isRecruiting 체크 없음
- 게시글 삭제시 신청에 대한 변경사항 없음

**TO-BE**
- isRecruiting = false인 요청에는 where에 isRecruiting 조건 삭제
- 게시글 검색시 countQuery에도 where 검색 조건 추가
- 게시글 수정시 모집 완료인 게시글은 Custom Exception 발생
- 글 삭제시 해당 글에 대기 상태인 신청들 거절 처리

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트 
